### PR TITLE
Fix double rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Using the following categories, list your changes in this order:
 
 ## [Unreleased]
 
--   Nothing (yet)!
+-   Fix double rendering issue on initial page load
 
 ## [1.0.2] - 2024-10-24
 

--- a/src/reactpy_router/routers.py
+++ b/src/reactpy_router/routers.py
@@ -74,13 +74,20 @@ def router(
     match = use_memo(lambda: _match_route(resolvers, location, select="first"))
 
     if match:
-        route_elements = [
-            _route_state_context(
-                element,
-                value=RouteState(set_location, params),
-            )
-            for element, params in match
-        ]
+        # We need skip rendering the application on 'first_load' to avoid
+        # rendering it twice. The second render occurs following
+        # the impending on_history_change event
+
+        if first_load:
+            route_elements = []
+        else:
+            route_elements = [
+                _route_state_context(
+                    element,
+                    value=RouteState(set_location, params),
+                )
+                for element, params in match
+            ]
 
         def on_history_change(event: dict[str, Any]) -> None:
             """Callback function used within the JavaScript `History` component."""

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -1,0 +1,62 @@
+import pytest
+from reactpy import component, html
+from reactpy.testing import DisplayFixture
+
+from reactpy_router import browser_router, route
+
+from .tooling.page import page_stable
+
+
+@pytest.mark.anyio
+async def test_router_simple(display: DisplayFixture):
+    """Confirm the number of rendering operations when new pages are first loaded"""
+    root_render_count = 0
+    home_page_render_count = 0
+    not_found_render_count = 0
+
+    @component
+    def root():
+        nonlocal root_render_count
+        root_render_count += 1
+
+        # https://reactive-python.github.io/reactpy-router/latest/#quick-start
+
+        @component
+        def home_page():
+            nonlocal home_page_render_count
+            home_page_render_count += 1
+            return html.h1("Home Page 🏠")
+
+        @component
+        def not_found():
+            nonlocal not_found_render_count
+            not_found_render_count += 1
+            return html.h1("Missing Link 🔗‍💥")
+
+        return browser_router(
+            route("/", home_page()),
+            route("{404:any}", not_found()),
+        )
+
+    await display.show(root)
+    await page_stable(display.page)
+
+    assert root_render_count == 1
+    assert home_page_render_count == 1
+    assert not_found_render_count == 0
+
+    await display.goto("/xxx")
+    await page_stable(display.page)
+
+    assert root_render_count == 2
+    assert home_page_render_count == 1
+    assert not_found_render_count == 1
+
+    await display.goto("/yyy")
+    await page_stable(display.page)
+
+    assert root_render_count == 3
+    assert home_page_render_count == 1
+    assert not_found_render_count == 2
+
+    assert True

--- a/tests/tooling/page.py
+++ b/tests/tooling/page.py
@@ -1,0 +1,7 @@
+from playwright.async_api._generated import Page
+
+
+async def page_stable(page: Page) -> None:
+    """Only return when network is idle and DOM has loaded"""
+    await page.wait_for_load_state("networkidle")
+    await page.wait_for_load_state("domcontentloaded")


### PR DESCRIPTION
## Description

I noticed that the router renders the application markup twice when the page is first loaded. I've changed the router so
that the the initial render is dismissed. The following *on_first_load()* event triggers the second render which 
proceeds as normal.

All exiting tests pass. I've added an additional test to confirm that double rendering no longer occurs.

Cheers, Steve.

## Checklist

Please update this checklist as you complete each item:

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [ ] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
