### PR TITLE
Allow `navigate` component to accept integers for go back/forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Don't forget to remove deprecated code on each major release!
 
 ### Added
 
+- The `navigate` component now accepts integers for `to`, allowing relative navigation in the browser's history stack (e.g. `navigate(-1)` to go back, `navigate(1)` to go forward).
 - Support for ReactPy v2.x (beta). The initial URL is now sourced from the ReactPy executor (`use_connection().location`) instead of a JS-side `popstate` effect, removing a redundant network round-trip on first load.
 
 ### Changed

--- a/src/js/src/components.ts
+++ b/src/js/src/components.ts
@@ -100,12 +100,19 @@ export function Navigate({
   replace = false,
 }: NavigateProps): null {
   React.useEffect(() => {
-    if (replace) {
-      replaceState(to);
+    if (typeof to === "number") {
+      // Relative history navigation (e.g. go back / go forward).
+      // The resulting popstate event is picked up by the History
+      // component, so no explicit callback is needed here.
+      window.history.go(to);
     } else {
-      pushState(to);
+      if (replace) {
+        replaceState(to);
+      } else {
+        pushState(to);
+      }
+      onNavigateCallback(createLocationObject());
     }
-    onNavigateCallback(createLocationObject());
     return () => {};
   }, []);
 

--- a/src/js/src/types.ts
+++ b/src/js/src/types.ts
@@ -14,6 +14,6 @@ export interface LinkProps {
 
 export interface NavigateProps {
   onNavigateCallback: (location: ReactPyLocation) => void;
-  to: string;
+  to: string | number;
   replace?: boolean;
 }

--- a/src/reactpy_router/components.py
+++ b/src/reactpy_router/components.py
@@ -110,13 +110,14 @@ def _navigate(to: str | int, replace: bool = False) -> VdomDict | None:
     def on_navigate_callback(_event: dict[str, Any]) -> None:
         set_location(Location(**_event))
 
-    if type(to) is int:
+    if isinstance(to, int):
         # Integer navigation (go back/forward) — always delegate to JS;
         # the resulting popstate event is handled by the History component.
         return Navigate({"onNavigateCallback": on_navigate_callback, "to": to, "replace": replace})
 
-    new_path = to.split("?", 1)[0]
-    if location.path != new_path:
-        return Navigate({"onNavigateCallback": on_navigate_callback, "to": to, "replace": replace})
+    if isinstance(to, str):
+        new_path = to.split("?", 1)[0]
+        if location.path != new_path:
+            return Navigate({"onNavigateCallback": on_navigate_callback, "to": to, "replace": replace})
 
     return None

--- a/src/reactpy_router/components.py
+++ b/src/reactpy_router/components.py
@@ -83,16 +83,18 @@ def route(path: str, element: Any | None, *routes: Route) -> Route:
     return Route(path, element, routes)
 
 
-def navigate(to: str, replace: bool = False, key: Key | None = None) -> Component:
+def navigate(to: str | int, replace: bool = False, key: Key | None = None) -> Component:
     """
     Navigate to a specified URL.
 
     This function changes the browser's current URL when it is rendered.
 
     Args:
-        to: The target URL to navigate to.
+        to: The target URL to navigate to, or an integer indicating the relative
+            position in the browser's history stack (e.g., ``-1`` to go back,
+            ``1`` to go forward). See `History.go <https://developer.mozilla.org/en-US/docs/Web/API/History/go>`_.
         replace: If True, the current history entry will be replaced \
-            with the new URL. Defaults to False.
+            with the new URL. Ignored when ``to`` is an integer. Defaults to False.
 
     Returns:
         The component responsible for navigation.
@@ -101,14 +103,19 @@ def navigate(to: str, replace: bool = False, key: Key | None = None) -> Componen
 
 
 @component
-def _navigate(to: str, replace: bool = False) -> VdomDict | None:
+def _navigate(to: str | int, replace: bool = False) -> VdomDict | None:
     location = use_connection().location
     set_location = _use_route_state().set_location
-    new_path = to.split("?", 1)[0]
 
     def on_navigate_callback(_event: dict[str, Any]) -> None:
         set_location(Location(**_event))
 
+    if isinstance(to, int):
+        # Integer navigation (go back/forward) — always delegate to JS;
+        # the resulting popstate event is handled by the History component.
+        return Navigate({"onNavigateCallback": on_navigate_callback, "to": to, "replace": replace})
+
+    new_path = to.split("?", 1)[0]
     if location.path != new_path:
         return Navigate({"onNavigateCallback": on_navigate_callback, "to": to, "replace": replace})
 

--- a/src/reactpy_router/components.py
+++ b/src/reactpy_router/components.py
@@ -110,7 +110,7 @@ def _navigate(to: str | int, replace: bool = False) -> VdomDict | None:
     def on_navigate_callback(_event: dict[str, Any]) -> None:
         set_location(Location(**_event))
 
-    if isinstance(to, int):
+    if isinstance(to, int) and not isinstance(to, bool):
         # Integer navigation (go back/forward) — always delegate to JS;
         # the resulting popstate event is handled by the History component.
         return Navigate({"onNavigateCallback": on_navigate_callback, "to": to, "replace": replace})

--- a/src/reactpy_router/components.py
+++ b/src/reactpy_router/components.py
@@ -110,7 +110,7 @@ def _navigate(to: str | int, replace: bool = False) -> VdomDict | None:
     def on_navigate_callback(_event: dict[str, Any]) -> None:
         set_location(Location(**_event))
 
-    if isinstance(to, int) and not isinstance(to, bool):
+    if type(to) is int:
         # Integer navigation (go back/forward) — always delegate to JS;
         # the resulting popstate event is handled by the History component.
         return Navigate({"onNavigateCallback": on_navigate_callback, "to": to, "replace": replace})

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -355,3 +355,97 @@ async def test_navigate_component_to_current_url(display: DisplayFixture):
     await display.page.wait_for_selector("#nav-a")
     await display.page.go_back()
     await display.page.wait_for_selector("#root-a")
+
+
+async def test_navigate_component_go_back(display: DisplayFixture):
+    """Navigate back using navigate(-1)."""
+
+    @component
+    def nav_btn():
+        nav, set_nav = use_state("")
+
+        return html.button(
+            {"onClick": lambda _: set_nav("/a")},
+            navigate(nav) if nav else "Go to A",
+        )
+
+    @component
+    def back_btn():
+        delta, set_delta = use_state("")
+
+        return html.button(
+            {"onClick": lambda _: set_delta(-1)},
+            navigate(delta) if isinstance(delta, int) else "Go back",
+        )
+
+    @component
+    def sample():
+        return browser_router(
+            route("/", nav_btn()),
+            route("/a", back_btn()),
+        )
+
+    await display.show(sample)
+
+    # Navigate to /a using the link
+    btn = await display.page.wait_for_selector("button")
+    assert await btn.text_content() == "Go to A"
+    await btn.click()
+
+    # Go back using navigate(-1)
+    btn = await display.page.wait_for_selector("button")
+    assert await btn.text_content() == "Go back"
+    await btn.click()
+
+    # Verify we're back at the root route
+    btn = await display.page.wait_for_selector("button")
+    assert await btn.text_content() == "Go to A"
+
+
+async def test_navigate_component_go_forward(display: DisplayFixture):
+    """Navigate forward using navigate(1)."""
+
+    @component
+    def forward_btn():
+        delta, set_delta = use_state("")
+
+        return html.button(
+            {"onClick": lambda _: set_delta(1), "id": "go-forward"},
+            navigate(delta) if isinstance(delta, int) else "Go forward",
+        )
+
+    @component
+    def back_btn():
+        delta, set_delta = use_state("")
+
+        return html.button(
+            {"onClick": lambda _: set_delta(-1), "id": "go-back"},
+            navigate(delta) if isinstance(delta, int) else "Go back",
+        )
+
+    @component
+    def sample():
+        return browser_router(
+            route("/", forward_btn()),
+            route("/a", back_btn()),
+        )
+
+    await display.show(sample)
+
+    # Navigate to /a via full page load (builds forward history entry)
+    await display.goto("/a")
+    await display.page.wait_for_selector("#go-back")
+
+    # Go back to / via navigate(-1)
+    await display.page.click("#go-back")
+
+    # Should now be at / with the "Go forward" button
+    await display.page.wait_for_selector("#go-forward")
+    assert await display.page.text_content("#go-forward") == "Go forward"
+
+    # Go forward to /a via navigate(1)
+    await display.page.click("#go-forward")
+
+    # Verify we're back at /a
+    await display.page.wait_for_selector("#go-back")
+    assert await display.page.text_content("#go-back") == "Go back"

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -364,18 +364,24 @@ async def test_navigate_component_go_back(display: DisplayFixture):
     def nav_btn():
         nav, set_nav = use_state("")
 
+        if nav:
+            return navigate(nav)
+
         return html.button(
-            {"onClick": lambda _: set_nav("/a")},
-            navigate(nav) if nav else "Go to A",
+            {"onClick": lambda _: set_nav("/a"), "id": "nav-to-a"},
+            "Go to A",
         )
 
     @component
     def back_btn():
         delta, set_delta = use_state("")
 
+        if isinstance(delta, int):
+            return navigate(delta)
+
         return html.button(
-            {"onClick": lambda _: set_delta(-1)},
-            navigate(delta) if isinstance(delta, int) else "Go back",
+            {"onClick": lambda _: set_delta(-1), "id": "go-back"},
+            "Go back",
         )
 
     @component
@@ -387,19 +393,20 @@ async def test_navigate_component_go_back(display: DisplayFixture):
 
     await display.show(sample)
 
-    # Navigate to /a using the link
-    btn = await display.page.wait_for_selector("button")
-    assert await btn.text_content() == "Go to A"
-    await btn.click()
+    # Navigate to /a
+    await display.page.wait_for_selector("#nav-to-a")
+    await display.page.click("#nav-to-a")
+
+    # Wait for the go-back button to appear on route /a
+    await display.page.wait_for_selector("#go-back")
+    assert await display.page.text_content("#go-back") == "Go back"
 
     # Go back using navigate(-1)
-    btn = await display.page.wait_for_selector("button")
-    assert await btn.text_content() == "Go back"
-    await btn.click()
+    await display.page.click("#go-back")
 
     # Verify we're back at the root route
-    btn = await display.page.wait_for_selector("button")
-    assert await btn.text_content() == "Go to A"
+    await display.page.wait_for_selector("#nav-to-a")
+    assert await display.page.text_content("#nav-to-a") == "Go to A"
 
 
 async def test_navigate_component_go_forward(display: DisplayFixture):
@@ -409,18 +416,24 @@ async def test_navigate_component_go_forward(display: DisplayFixture):
     def forward_btn():
         delta, set_delta = use_state("")
 
+        if isinstance(delta, int):
+            return navigate(delta)
+
         return html.button(
             {"onClick": lambda _: set_delta(1), "id": "go-forward"},
-            navigate(delta) if isinstance(delta, int) else "Go forward",
+            "Go forward",
         )
 
     @component
     def back_btn():
         delta, set_delta = use_state("")
 
+        if isinstance(delta, int):
+            return navigate(delta)
+
         return html.button(
             {"onClick": lambda _: set_delta(-1), "id": "go-back"},
-            navigate(delta) if isinstance(delta, int) else "Go back",
+            "Go back",
         )
 
     @component
@@ -434,9 +447,9 @@ async def test_navigate_component_go_forward(display: DisplayFixture):
 
     # Navigate to /a via full page load (builds forward history entry)
     await display.goto("/a")
-    await display.page.wait_for_selector("#go-back")
 
     # Go back to / via navigate(-1)
+    await display.page.wait_for_selector("#go-back")
     await display.page.click("#go-back")
 
     # Should now be at / with the "Go forward" button


### PR DESCRIPTION
## Description

Allow the `navigate` component to accept integers for the `to` parameter, enabling relative navigation in the browser's history stack — e.g., `navigate(-1)` to go back, `navigate(1)` to go forward.

This works by:
- **Python side**: `to` parameter typed as `str | int`. When an integer is received, the path-matching comparison is skipped (since an integer has no path to compare), and the JS-side Navigate component is always rendered.
- **JS side**: The `Navigate` component checks `typeof to === "number"` and calls `window.history.go(to)`. The resulting `popstate` event is handled by the existing `History` component, which already updates the server-side location state — so no duplicate callback is needed.
- **TypeScript**: `NavigateProps.to` updated to `string | number`.

## Checklist

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

Closes #52

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>